### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/qSIP/Network.cpp
+++ b/qSIP/Network.cpp
@@ -10,6 +10,7 @@
 #include <QString>
 #include <QStringList>
 #include <stdint.h>
+#include <sys/socket.h>
 
 Network::Network()
 {


### PR DESCRIPTION
This fixes compilation on FreeBSD.
But linking still fails with

```
sudo pkg install libg722
qmake-qt5
make -j4

ld: error: unable to find library -lbaresip
ld: error: unable to find library -lwebrtc
```